### PR TITLE
Fix: 위키 사이드 메뉴에서 자식 위키가 없는 부모 위키는 전개 버튼을 감추도록 변경

### DIFF
--- a/src/components/wiki/RenderWikiForm.tsx
+++ b/src/components/wiki/RenderWikiForm.tsx
@@ -3,29 +3,21 @@ import * as FormStyled from "./RenderWikiFormStyle";
 import { WikiFormProps } from "@/components/wiki/WikiCommonType";
 import "@toast-ui/editor/dist/i18n/ko-kr";
 import { MarkdownEditor } from "./MarkdownEditor";
-import { db } from "../../../firebase";
-import { getDocs, collection, where, query } from "firebase/firestore";
 
 export default function WikiForm({
   form,
   onFormChange,
   editorRef,
   parents,
+  hasChildMap,
 }: WikiFormProps) {
-  const hasChildWikis = async (wikiID: string) => {
-    const wikisCollection = collection(db, "Wiki");
-    const q = query(wikisCollection, where("parentID", "==", wikiID));
-    const snapshot = await getDocs(q);
-    return !snapshot.empty;
-  };
-
   const handleParentChange = async (
     e: React.ChangeEvent<HTMLSelectElement>,
   ) => {
     const newParentID = e.target.value;
     const isNewWiki = () => form.wikiID === "";
 
-    const hasChild = await hasChildWikis(form.wikiID);
+    const hasChild = hasChildMap[form.wikiID];
 
     // 현재 위키가 자식을 가지고 있지 않고, 선택한 parentID가 현재 위키의 자식 위키가 아니면 변경 허용
     if (isNewWiki() || (!hasChild && newParentID !== form.wikiID)) {

--- a/src/components/wiki/WikiCategoryList.tsx
+++ b/src/components/wiki/WikiCategoryList.tsx
@@ -5,6 +5,7 @@ import { IoIosArrowDown, IoIosArrowUp } from "react-icons/Io";
 
 const WikiCategoryList = ({
   WiKiList,
+  hasChildMap,
   onEntryClick,
   onArrowClick,
   isVisible,
@@ -43,13 +44,15 @@ const WikiCategoryList = ({
                 <Styled.WikiTitle selected={wiki.wikiID === selectedWikiId}>
                   {wiki.title}
                 </Styled.WikiTitle>
-                <Styled.ArrowIcon onClick={() => handleArrowClick(wiki)}>
-                  {unfoldedWikiIds.includes(wiki.wikiID) ? (
-                    <IoIosArrowUp />
-                  ) : (
-                    <IoIosArrowDown />
-                  )}
-                </Styled.ArrowIcon>
+                {hasChildMap[wiki.wikiID] && (
+                  <Styled.ArrowIcon onClick={() => handleArrowClick(wiki)}>
+                    {unfoldedWikiIds.includes(wiki.wikiID) ? (
+                      <IoIosArrowUp />
+                    ) : (
+                      <IoIosArrowDown />
+                    )}
+                  </Styled.ArrowIcon>
+                )}
               </Styled.ParentWikiWrapper>
             ) : (
               <>

--- a/src/components/wiki/WikiCommonType.ts
+++ b/src/components/wiki/WikiCommonType.ts
@@ -32,6 +32,7 @@ export type WikiTopProps = {
 
 export type WikiCategoryProps = {
   WiKiList: Wiki[];
+  hasChildMap: HasChildMap;
   onEntryClick: (entry: Wiki) => void;
   onArrowClick: (entry: Wiki) => void;
   isVisible: boolean;
@@ -39,15 +40,18 @@ export type WikiCategoryProps = {
 
 export type WikiFormProps = {
   form: Wiki;
+  parents: Wiki[];
+  hasChildMap: HasChildMap;
   onFormChange: (key: keyof Wiki, value: string) => void;
   editorRef: React.MutableRefObject<Editor | null>;
-  parents: Wiki[];
 };
 
 export type WikiContentProps = {
   currentUser: string;
   Wiki: Wiki | null;
   form: Wiki;
+  parents: Wiki[];
+  hasChildMap: HasChildMap;
   isEditMode: boolean;
   isLoading: boolean;
   onFormChange: (key: keyof Wiki, value: string) => void;
@@ -55,7 +59,6 @@ export type WikiContentProps = {
   onWikiDeleteButtonClick: () => void;
   toggleEditMode: () => void;
   editorRef: React.MutableRefObject<Editor | null>;
-  parents: Wiki[];
 };
 
 export type RenderWikiContentProps = {
@@ -64,4 +67,8 @@ export type RenderWikiContentProps = {
   onWikiEditButtonClick: () => void;
   onWikiDeleteButtonClick: () => void;
   toggleEditMode: () => void;
+};
+
+export type HasChildMap = {
+  [wikiID: string]: boolean;
 };

--- a/src/components/wiki/WikiContent.tsx
+++ b/src/components/wiki/WikiContent.tsx
@@ -9,6 +9,7 @@ export default function WikiContent({
   Wiki,
   form,
   parents,
+  hasChildMap,
   isEditMode,
   isLoading,
   editorRef,
@@ -21,6 +22,7 @@ export default function WikiContent({
     form,
     editorRef,
     parents,
+    hasChildMap,
     onFormChange,
   };
   const wikiContentProps = {

--- a/src/firebase/services/wikiService.ts
+++ b/src/firebase/services/wikiService.ts
@@ -1,0 +1,9 @@
+import { collection, getDocs, query, where } from "firebase/firestore";
+import { db } from "../../../firebase";
+
+export const hasChildWikis = async (wikiID: string) => {
+  const wikisCollection = collection(db, "Wiki");
+  const q = query(wikisCollection, where("parentID", "==", wikiID));
+  const snapshot = await getDocs(q);
+  return !snapshot.empty;
+};


### PR DESCRIPTION
## Summary

- 위키 사이드 메뉴에서 자식 위키가 없는 부모 위키는 전개 버튼을 감추도록 변경하였습니다.
- 이를 위해 위키의 자식 위키가 존재하는지 체크하는 로직을 추가하였고, 해당 기능은 위키 폼의 부모 위키 선택 기능에서도 공통으로 사용하도록 변경하였습니다.
- firebase 관련 로직들을 일부 `firebase/wiki/wikiService.ts` 로 옮겼으며, 리팩토링을 통해 추가적으로 옮겨줄 예정입니다.

## Issue number and link
#92 